### PR TITLE
Add omitempty JSON attribute for some fields

### DIFF
--- a/config_linux.go
+++ b/config_linux.go
@@ -23,16 +23,16 @@ type Cgroup struct {
 
 	// Path specifies the path to cgroups that are created and/or joined by the container.
 	// The path is assumed to be relative to the host system cgroup mountpoint.
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
-	// ScopePrefix describes prefix for the scope name
-	ScopePrefix string `json:"scope_prefix"`
+	// ScopePrefix describes prefix for the scope name.
+	ScopePrefix string `json:"scope_prefix,omitempty"`
 
-	// Resources contains various cgroups settings to apply
-	*Resources
+	// Resources contains various cgroups settings to apply.
+	*Resources `json:"Resources,omitempty"`
 
 	// Systemd tells if systemd should be used to manage cgroups.
-	Systemd bool
+	Systemd bool `json:"Systemd,omitempty"`
 
 	// SystemdProps are any additional properties for systemd,
 	// derived from org.systemd.property.xxx annotations.
@@ -40,7 +40,7 @@ type Cgroup struct {
 	SystemdProps []systemdDbus.Property `json:"-"`
 
 	// Rootless tells if rootless cgroups should be used.
-	Rootless bool
+	Rootless bool `json:"Rootless,omitempty"`
 
 	// The host UID that should own the cgroup, or nil to accept
 	// the default ownership.  This should only be set when the
@@ -52,96 +52,96 @@ type Cgroup struct {
 
 type Resources struct {
 	// Devices is the set of access rules for devices in the container.
-	Devices []*devices.Rule `json:"devices"`
+	Devices []*devices.Rule `json:"devices,omitempty"`
 
-	// Memory limit (in bytes)
-	Memory int64 `json:"memory"`
+	// Memory limit (in bytes).
+	Memory int64 `json:"memory,omitempty"`
 
-	// Memory reservation or soft_limit (in bytes)
-	MemoryReservation int64 `json:"memory_reservation"`
+	// Memory reservation or soft_limit (in bytes).
+	MemoryReservation int64 `json:"memory_reservation,omitempty"`
 
-	// Total memory usage (memory + swap); set `-1` to enable unlimited swap
-	MemorySwap int64 `json:"memory_swap"`
+	// Total memory usage (memory+swap); use -1 for unlimited swap.
+	MemorySwap int64 `json:"memory_swap,omitempty"`
 
-	// CPU shares (relative weight vs. other containers)
-	CpuShares uint64 `json:"cpu_shares"`
+	// CPU shares (relative weight vs. other containers).
+	CpuShares uint64 `json:"cpu_shares,omitempty"` //nolint:revive // Suppress "var-naming: struct field CpuShares should be CPUShares".
 
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
-	CpuQuota int64 `json:"cpu_quota"`
+	CpuQuota int64 `json:"cpu_quota,omitempty"` //nolint:revive // Suppress "var-naming: struct field CpuQuota should be CPUQuota".
 
 	// CPU hardcap burst limit (in usecs). Allowed accumulated cpu time additionally for burst in a given period.
-	CpuBurst *uint64 `json:"cpu_burst"` //nolint:revive
+	CpuBurst *uint64 `json:"cpu_burst,omitempty"` //nolint:revive // Suppress "var-naming: struct field CpuBurst should be CPUBurst".
 
 	// CPU period to be used for hardcapping (in usecs). 0 to use system default.
-	CpuPeriod uint64 `json:"cpu_period"`
+	CpuPeriod uint64 `json:"cpu_period,omitempty"` //nolint:revive // Suppress "var-naming: struct field CpuPeriod should be CPUPeriod".
 
 	// How many time CPU will use in realtime scheduling (in usecs).
-	CpuRtRuntime int64 `json:"cpu_rt_quota"`
+	CpuRtRuntime int64 `json:"cpu_rt_quota,omitempty"` //nolint:revive // Suppress "var-naming: struct field CpuRtRuntime should be CPURtRuntime".
 
 	// CPU period to be used for realtime scheduling (in usecs).
-	CpuRtPeriod uint64 `json:"cpu_rt_period"`
+	CpuRtPeriod uint64 `json:"cpu_rt_period,omitempty"` //nolint:revive // Suppress "var-naming: struct field CpuQuota should be CPUQuota".
 
-	// CPU to use
-	CpusetCpus string `json:"cpuset_cpus"`
+	// Cpuset CPUs to use.
+	CpusetCpus string `json:"cpuset_cpus,omitempty"`
 
-	// MEM to use
-	CpusetMems string `json:"cpuset_mems"`
+	// Cpuset memory nodes to use.
+	CpusetMems string `json:"cpuset_mems,omitempty"`
 
-	// cgroup SCHED_IDLE
+	// Cgroup's SCHED_IDLE value.
 	CPUIdle *int64 `json:"cpu_idle,omitempty"`
 
 	// Process limit; set <= `0' to disable limit.
-	PidsLimit int64 `json:"pids_limit"`
+	PidsLimit int64 `json:"pids_limit,omitempty"`
 
 	// Specifies per cgroup weight, range is from 10 to 1000.
-	BlkioWeight uint16 `json:"blkio_weight"`
+	BlkioWeight uint16 `json:"blkio_weight,omitempty"`
 
-	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, range is from 10 to 1000, cfq scheduler only
-	BlkioLeafWeight uint16 `json:"blkio_leaf_weight"`
+	// Tasks' weight in the given cgroup while competing with the cgroup's child cgroups, range is from 10 to 1000, cfq scheduler only.
+	BlkioLeafWeight uint16 `json:"blkio_leaf_weight,omitempty"`
 
 	// Weight per cgroup per device, can override BlkioWeight.
-	BlkioWeightDevice []*WeightDevice `json:"blkio_weight_device"`
+	BlkioWeightDevice []*WeightDevice `json:"blkio_weight_device,omitempty"`
 
 	// IO read rate limit per cgroup per device, bytes per second.
-	BlkioThrottleReadBpsDevice []*ThrottleDevice `json:"blkio_throttle_read_bps_device"`
+	BlkioThrottleReadBpsDevice []*ThrottleDevice `json:"blkio_throttle_read_bps_device,omitempty"`
 
 	// IO write rate limit per cgroup per device, bytes per second.
-	BlkioThrottleWriteBpsDevice []*ThrottleDevice `json:"blkio_throttle_write_bps_device"`
+	BlkioThrottleWriteBpsDevice []*ThrottleDevice `json:"blkio_throttle_write_bps_device,omitempty"`
 
 	// IO read rate limit per cgroup per device, IO per second.
-	BlkioThrottleReadIOPSDevice []*ThrottleDevice `json:"blkio_throttle_read_iops_device"`
+	BlkioThrottleReadIOPSDevice []*ThrottleDevice `json:"blkio_throttle_read_iops_device,omitempty"`
 
 	// IO write rate limit per cgroup per device, IO per second.
-	BlkioThrottleWriteIOPSDevice []*ThrottleDevice `json:"blkio_throttle_write_iops_device"`
+	BlkioThrottleWriteIOPSDevice []*ThrottleDevice `json:"blkio_throttle_write_iops_device,omitempty"`
 
-	// set the freeze value for the process
-	Freezer FreezerState `json:"freezer"`
+	// Freeze value for the process.
+	Freezer FreezerState `json:"freezer,omitempty"`
 
-	// Hugetlb limit (in bytes)
-	HugetlbLimit []*HugepageLimit `json:"hugetlb_limit"`
+	// Hugetlb limit (in bytes).
+	HugetlbLimit []*HugepageLimit `json:"hugetlb_limit,omitempty"`
 
-	// Whether to disable OOM Killer
-	OomKillDisable bool `json:"oom_kill_disable"`
+	// Whether to disable OOM killer.
+	OomKillDisable bool `json:"oom_kill_disable,omitempty"`
 
-	// Tuning swappiness behaviour per cgroup
-	MemorySwappiness *uint64 `json:"memory_swappiness"`
+	// Tuning swappiness behaviour per cgroup.
+	MemorySwappiness *uint64 `json:"memory_swappiness,omitempty"`
 
-	// Set priority of network traffic for container
-	NetPrioIfpriomap []*IfPrioMap `json:"net_prio_ifpriomap"`
+	// Set priority of network traffic for container.
+	NetPrioIfpriomap []*IfPrioMap `json:"net_prio_ifpriomap,omitempty"`
 
-	// Set class identifier for container's network packets
-	NetClsClassid uint32 `json:"net_cls_classid_u"`
+	// Set class identifier for container's network packets.
+	NetClsClassid uint32 `json:"net_cls_classid_u,omitempty"`
 
-	// Rdma resource restriction configuration
-	Rdma map[string]LinuxRdma `json:"rdma"`
+	// Rdma resource restriction configuration.
+	Rdma map[string]LinuxRdma `json:"rdma,omitempty"`
 
 	// Used on cgroups v2:
 
 	// CpuWeight sets a proportional bandwidth limit.
-	CpuWeight uint64 `json:"cpu_weight"`
+	CpuWeight uint64 `json:"cpu_weight,omitempty"` //nolint:revive // Suppress "var-naming: struct field CpuWeight should be CPUWeight".
 
 	// Unified is cgroupv2-only key-value map.
-	Unified map[string]string `json:"unified"`
+	Unified map[string]string `json:"unified,omitempty"`
 
 	// SkipDevices allows to skip configuring device permissions.
 	// Used by e.g. kubelet while creating a parent cgroup (kubepods)
@@ -165,5 +165,5 @@ type Resources struct {
 	// MemoryCheckBeforeUpdate is a flag for cgroup v2 managers to check
 	// if the new memory limits (Memory and MemorySwap) being set are lower
 	// than the current memory usage, and reject if so.
-	MemoryCheckBeforeUpdate bool `json:"memory_check_before_update"`
+	MemoryCheckBeforeUpdate bool `json:"memory_check_before_update,omitempty"`
 }

--- a/devices/config/device.go
+++ b/devices/config/device.go
@@ -20,10 +20,10 @@ type Device struct {
 	FileMode os.FileMode `json:"file_mode"`
 
 	// Uid of the device.
-	Uid uint32 `json:"uid"`
+	Uid uint32 `json:"uid,omitempty"` //nolint:revive // Suppress "var-naming: struct field Uid should be UID".
 
 	// Gid of the device.
-	Gid uint32 `json:"gid"`
+	Gid uint32 `json:"gid,omitempty"` //nolint:revive // Suppress "var-naming: struct field Gid should be GID".
 }
 
 // Permissions is a cgroupv1-style string to represent device access. It


### PR DESCRIPTION
This allows to skip marshalling the default/empty/zero values, thus making the resulting JSON smaller.

While at it, ensure the comment is ending with a comma.

See also: opencontainers/runc#4685