### PR TITLE
Switch to golangci-lint v2, fix or suppress new warnings

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,9 +27,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.GO_VERSION }}"
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'

--- a/.golangci-extra.yml
+++ b/.golangci-extra.yml
@@ -2,11 +2,20 @@
 # github PRs only (see lint-extra in .github/workflows/validate.yml).
 #
 # For the default linter config, see .golangci.yml. This config should
-# only enable additional linters not enabled in the default config.
+# only enable additional linters and/or linter settings not enabled
+# in the default config.
+version: "2"
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - godot
     - revive
-
+    - staticcheck
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression.
+  exclusions:
+    generated: strict

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,31 @@
 # For documentation, see https://golangci-lint.run/usage/configuration/
+version: "2"
+
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: strict
 
 linters:
   enable:
     - errorlint
-    - gofumpt
     - nolintlint
     - unconvert
     - unparam
-
-linters-settings:
-  govet:
-    enable:
-      - nilness
+  settings:
+    govet:
+      enable:
+        - nilness
+    staticcheck:
+      checks:
+        - all
+        - -ST1000 # https://staticcheck.dev/docs/checks/#ST1000 Incorrect or missing package comment.
+        - -ST1003 # https://staticcheck.dev/docs/checks/#ST1003 Poorly chosen identifier.
+        - -ST1005 # https://staticcheck.dev/docs/checks/#ST1005 Incorrectly formatted error string.
+        - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression.
+  exclusions:
+    generated: strict
+    presets:
+      - comments
+      - std-error-handling

--- a/devices/devices_emulator.go
+++ b/devices/devices_emulator.go
@@ -304,8 +304,9 @@ func emulatorFromList(list io.Reader) (*emulator, error) {
 // This function is the sole reason for all of emulator -- to allow us
 // to figure out how to update a containers' cgroups without causing spurious
 // device errors (if possible).
-func (source *emulator) Transition(target *emulator) ([]*devices.Rule, error) { //nolint:revive // Ignore receiver-naming warning.
+func (e *emulator) Transition(target *emulator) ([]*devices.Rule, error) {
 	var transitionRules []*devices.Rule
+	source := e
 	oldRules := source.rules
 
 	// If the default policy doesn't match, we need to include a "disruptive"

--- a/devices/devices_emulator.go
+++ b/devices/devices_emulator.go
@@ -261,7 +261,7 @@ func (e *emulator) Apply(rule devices.Rule) error {
 }
 
 // emulatorFromList takes a reader to a "devices.list"-like source, and returns
-// a new Emulator that represents the state of the devices cgroup. Note that
+// a new emulator that represents the state of the devices cgroup. Note that
 // black-list devices cgroups cannot be fully reconstructed, due to limitations
 // in the devices cgroup API. Instead, such cgroups are always treated as
 // "allow all" cgroups.
@@ -301,7 +301,7 @@ func emulatorFromList(list io.Reader) (*emulator, error) {
 // disruptive rules (like denying all device access) will only be applied if
 // necessary.
 //
-// This function is the sole reason for all of Emulator -- to allow us
+// This function is the sole reason for all of emulator -- to allow us
 // to figure out how to update a containers' cgroups without causing spurious
 // device errors (if possible).
 func (source *emulator) Transition(target *emulator) ([]*devices.Rule, error) { //nolint:revive // Ignore receiver-naming warning.

--- a/fs2/memory.go
+++ b/fs2/memory.go
@@ -54,7 +54,7 @@ func setMemory(dirPath string, r *cgroups.Resources) error {
 	if swapStr != "" {
 		if err := cgroups.WriteFile(dirPath, "memory.swap.max", swapStr); err != nil {
 			// If swap is not enabled, silently ignore setting to max or disabling it.
-			if !(errors.Is(err, os.ErrNotExist) && (swapStr == "max" || swapStr == "0")) {
+			if !(errors.Is(err, os.ErrNotExist) && (swapStr == "max" || swapStr == "0")) { //nolint:staticcheck // Ignore "QF1001: could apply De Morgan's law".
 				return err
 			}
 		}

--- a/fs2/memory.go
+++ b/fs2/memory.go
@@ -18,17 +18,14 @@ import (
 // cgroupv2 files with .min, .max, .low, or .high suffix.
 // The value of -1 is converted to "max" for cgroupv1 compatibility
 // (which used to write -1 to remove the limit).
-func numToStr(value int64) (ret string) {
-	switch {
-	case value == 0:
-		ret = ""
-	case value == -1:
-		ret = "max"
-	default:
-		ret = strconv.FormatInt(value, 10)
+func numToStr(value int64) string {
+	switch value {
+	case 0:
+		return ""
+	case -1:
+		return "max"
 	}
-
-	return ret
+	return strconv.FormatInt(value, 10)
 }
 
 func isMemorySet(r *cgroups.Resources) bool {


### PR DESCRIPTION
Please see individual commits for details.

~~(This is based on and includes #10;will rebase if #10 will be merged first).~~