### PR TITLE
Add ConvertCPUSharesToCPUWeight

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -534,16 +534,27 @@ func TestGetHugePageSizeImpl(t *testing.T) {
 	}
 }
 
-func TestConvertCPUSharesToCgroupV2Value(t *testing.T) {
-	cases := map[uint64]uint64{
-		0:      0,
-		2:      1,
-		262144: 10000,
+func TestConvertCPUSharesToCPUWeight(t *testing.T) {
+	cases := []struct {
+		in, out uint64
+		isErr   bool
+	}{
+		{in: 0, out: 0},
+		{in: 2, out: 1},
+		{in: 262144, out: 10000},
+		{in: 1, isErr: true},
+		{in: 262145, isErr: true},
 	}
-	for i, expected := range cases {
-		got := ConvertCPUSharesToCgroupV2Value(i)
-		if got != expected {
-			t.Errorf("expected ConvertCPUSharesToCgroupV2Value(%d) to be %d, got %d", i, expected, got)
+	for _, tc := range cases {
+		got, err := ConvertCPUSharesToCPUWeight(tc.in)
+		if tc.isErr {
+			if err == nil {
+				t.Errorf("ConvertCPUSharesToCPUWeight(%d): expected error, got nil", tc.in)
+			}
+		} else if err != nil {
+			t.Errorf("ConvertCPUSharesToCPUWeight(%d): expected error, got nil", tc.in)
+		} else if got != tc.out {
+			t.Errorf("ConvertCPUSharesToCPUWeight(%d): want %d, got %d", tc.in, tc.out, got)
 		}
 	}
 }


### PR DESCRIPTION
The existing function, ConvertCPUSharesToCgroupV2Value, do not have a way to return an error, and thus can accept invalid cgroup v1 (cpu-shares) values and can return invalid cgroup v2 (cpu-weight) values.

Add a new one, ConvertCPUSharesToCPUWeight, which is identical but can return meaningful errors. Mark the old one as deprecated. Amend the test case to test the new implementation (and, since both are using the same formula, existing implementation is tested, too, except for 0).

Related to https://github.com/opencontainers/runc/issues/4755