### PR TITLE
Remove annotations from Resources

### DIFF
--- a/config_linux.go
+++ b/config_linux.go
@@ -29,7 +29,7 @@ type Cgroup struct {
 	ScopePrefix string `json:"scope_prefix,omitempty"`
 
 	// Resources contains various cgroups settings to apply.
-	*Resources `json:"Resources,omitempty"`
+	*Resources
 
 	// Systemd tells if systemd should be used to manage cgroups.
 	Systemd bool `json:"Systemd,omitempty"`


### PR DESCRIPTION
This results in different JSON than the older version:

Before commit fd4995c:

```json
    "cgroups": {
      ...
      "devices": [
        ...
```
After:

```json
    "cgroups": {
      ...
      "Resources": {
        "devices": [
          ...
```

This breaks backward compatibility for runc.

Fixes: fd4995c ("Add omitempty JSON attribute for some fields")