### PR TITLE
Implement AddPid for cgroup managers

### DIFF
--- a/cgroups.go
+++ b/cgroups.go
@@ -29,6 +29,11 @@ type Manager interface {
 	// can be used to merely create a cgroup.
 	Apply(pid int) error
 
+	// AddPid adds a process with a given pid to an existing cgroup.
+	// The subcgroup argument is either empty, or a path relative to
+	// a cgroup under under the manager's cgroup.
+	AddPid(subcgroup string, pid int) error
+
 	// GetPids returns the PIDs of all processes inside the cgroup.
 	GetPids() ([]int, error)
 

--- a/fs2/fs2.go
+++ b/fs2/fs2.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/opencontainers/cgroups"
@@ -81,6 +82,18 @@ func (m *Manager) Apply(pid int) error {
 		return err
 	}
 	return nil
+}
+
+// AddPid adds a process with a given pid to an existing cgroup.
+// The subcgroup argument is either empty, or a path relative to
+// a cgroup under under the manager's cgroup.
+func (m *Manager) AddPid(subcgroup string, pid int) error {
+	path := filepath.Join(m.dirPath, subcgroup)
+	if !strings.HasPrefix(path, m.dirPath) {
+		return fmt.Errorf("bad sub cgroup path: %s", subcgroup)
+	}
+
+	return cgroups.WriteCgroupProc(path, pid)
 }
 
 func (m *Manager) GetPids() ([]int, error) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/cilium/ebpf v0.17.3
-	github.com/coreos/go-systemd/v22 v22.5.0
+	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/cyphar/filepath-securejoin v0.4.1
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/moby/sys/mountinfo v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/cilium/ebpf v0.17.3 h1:FnP4r16PWYSE4ux6zN+//jMcW4nMVRvuTLVTvCjyyjg=
 github.com/cilium/ebpf v0.17.3/go.mod h1:G5EDHij8yiLzaqn0WjyfJHvRa+3aDlReIaLVRMvOyJk=
-github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
-github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
+github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,7 +9,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
-github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/systemd/v2.go
+++ b/systemd/v2.go
@@ -383,6 +383,16 @@ func cgroupFilesToChown() ([]string, error) {
 	return filesToChown, nil
 }
 
+// AddPid adds a process with a given pid to an existing cgroup.
+// The subcgroup argument is either empty, or a path relative to
+// a cgroup under under the manager's cgroup.
+func (m *UnifiedManager) AddPid(subcgroup string, pid int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return addPid(m.dbus, getUnitName(m.cgroups), subcgroup, pid)
+}
+
 func (m *UnifiedManager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
To this day, cgroup managers did not have an ability to add a process
to an existing cgroup. One might use cgroups.WriteCgroupProc, but
this is cgroupfs operation and does not take into account systemd.

Let's introduce AddPid, which will add a process, identified by PID,
to the cgroup (or, optionally, a sub cgroup) of the manager.

Implementation for systemd requires [1] and systemd >= v238.

~~Currently a draft until [1] is merged and released.~~

Being tested in https://github.com/opencontainers/runc/pull/4822.

[1]: https://github.com/coreos/go-systemd/pull/458