### PR TITLE
systemd: retry when the dbus connection returns EAGAIN

### DIFF
--- a/systemd/dbus_test.go
+++ b/systemd/dbus_test.go
@@ -1,0 +1,55 @@
+package systemd
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestParallelConnection(t *testing.T) {
+	if !IsRunningSystemd() {
+		t.Skip("Test requires systemd.")
+	}
+	var dms []*dbusConnManager
+	for range 600 {
+		dms = append(dms, newDbusConnManager(os.Geteuid() != 0))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		doneWg  sync.WaitGroup
+		startCh = make(chan struct{})
+		errCh   = make(chan error, 1)
+	)
+	for _, dm := range dms {
+		doneWg.Add(1)
+		go func(dm *dbusConnManager) {
+			defer doneWg.Done()
+			select {
+			case <-ctx.Done():
+				return
+			case <-startCh:
+				_, err := dm.newConnection()
+				if err != nil {
+					// Only bother trying to send the first error.
+					select {
+					case errCh <- err:
+					default:
+					}
+					cancel()
+				}
+			}
+		}(dm)
+	}
+	close(startCh) // trigger all connection attempts
+	doneWg.Wait()
+
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
+	}
+}


### PR DESCRIPTION
Before version 254, systemd used the glibc macro SOMAXCONN to set the backlog. Prior to Linux 5.4, SOMAXCONN was set to 128. If the number of instantaneous connections exceeds this value, newConnection will return EAGAIN, which can cause runc to fail when creating containers.