### PR TITLE
config: switch PidsLimit to *int64

### DIFF
--- a/config_linux.go
+++ b/config_linux.go
@@ -90,8 +90,8 @@ type Resources struct {
 	// Cgroup's SCHED_IDLE value.
 	CPUIdle *int64 `json:"cpu_idle,omitempty"`
 
-	// Process limit; set <= `0' to disable limit.
-	PidsLimit int64 `json:"pids_limit,omitempty"`
+	// Process limit; set < `0' to disable limit. `nil` means "keep current limit".
+	PidsLimit *int64 `json:"pids_limit,omitempty"`
 
 	// Specifies per cgroup weight, range is from 10 to 1000.
 	BlkioWeight uint16 `json:"blkio_weight,omitempty"`

--- a/devices/systemd_test.go
+++ b/devices/systemd_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/opencontainers/cgroups/systemd"
 )
 
+func toPtr[T any](v T) *T { return &v }
+
 // TestPodSkipDevicesUpdate checks that updating a pod having SkipDevices: true
 // does not result in spurious "permission denied" errors in a container
 // running under the pod. The test is somewhat similar in nature to the
@@ -32,7 +34,7 @@ func TestPodSkipDevicesUpdate(t *testing.T) {
 		Parent:  "system.slice",
 		Name:    podName,
 		Resources: &cgroups.Resources{
-			PidsLimit:   42,
+			PidsLimit:   toPtr[int64](42),
 			Memory:      32 * 1024 * 1024,
 			SkipDevices: true,
 		},
@@ -96,7 +98,7 @@ func TestPodSkipDevicesUpdate(t *testing.T) {
 
 	// Now update the pod a few times.
 	for range 42 {
-		podConfig.Resources.PidsLimit++
+		(*podConfig.Resources.PidsLimit)++
 		podConfig.Resources.Memory += 1024 * 1024
 		if err := pm.Set(podConfig.Resources); err != nil {
 			t.Fatal(err)

--- a/systemd/v2.go
+++ b/systemd/v2.go
@@ -176,6 +176,9 @@ func unifiedResToSystemdProps(cm *dbusConnManager, res map[string]string) (props
 					return nil, fmt.Errorf("unified resource %q value conversion error: %w", k, err)
 				}
 			}
+			if num == 0 {
+				num = 1 // systemd does not accept "0" for TasksMax
+			}
 			props = append(props,
 				newProp("TasksMax", num))
 
@@ -256,9 +259,17 @@ func genV2ResourcesProperties(dirPath string, r *cgroups.Resources, cm *dbusConn
 
 	addCPUQuota(cm, &properties, &r.CpuQuota, r.CpuPeriod)
 
-	if r.PidsLimit > 0 || r.PidsLimit == -1 {
+	if r.PidsLimit != nil {
+		var tasksMax uint64
+		if limit := *r.PidsLimit; limit < 0 {
+			tasksMax = math.MaxUint64 // "infinity"
+		} else if limit == 0 {
+			tasksMax = 1 // systemd does not accept "0" for TasksMax
+		} else {
+			tasksMax = uint64(limit)
+		}
 		properties = append(properties,
-			newProp("TasksMax", uint64(r.PidsLimit)))
+			newProp("TasksMax", tasksMax))
 	}
 
 	err = addCpuset(cm, &properties, r.CpusetCpus, r.CpusetMems)


### PR DESCRIPTION
Previously we would treat a value of "0" as meaning "no-op", which lead
to quite a bit of confusion. The runtime-spec has been updated to make
the "pids.limit" value a pointer, and explicitly state that:

 * Values >= 0 should be treated as normal values; and
 * -1 indicates "max".

In practice this means we should switch PidsLimit to an *int64. Luckily,
this is actually backwards-compatible with our previous JSON -- an old
value of "0" would be omitted from the output, which will now be parsed
as "nil". The handling by our cgroup code would be identical but the
latter now correctly reflects the guidance by the runtime-spec.

Ref: https://github.com/opencontainers/runc/issues/4014
Ref: https://github.com/opencontainers/runtime-spec/pull/1279
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>