### PR TITLE
config_rdma: change omitempty to omitzero

### DIFF
--- a/config_rdma.go
+++ b/config_rdma.go
@@ -3,7 +3,7 @@ package cgroups
 // LinuxRdma for Linux cgroup 'rdma' resource management (Linux 4.11)
 type LinuxRdma struct {
 	// Maximum number of HCA handles that can be opened. Default is "no limit".
-	HcaHandles *uint32 `json:"hca_handles,omitempty"`
+	HcaHandles *uint32 `json:"hca_handles,omitzero"`
 	// Maximum number of HCA objects that can be created. Default is "no limit".
-	HcaObjects *uint32 `json:"hca_objects,omitempty"`
+	HcaObjects *uint32 `json:"hca_objects,omitzero"`
 }


### PR DESCRIPTION
This change is a no-op for a pointer, and is only done for consistency with the rest of the code.

This should be a part of PR #28 but had somehow slipped.