### PR TITLE
systemd: add SetUnified for direct cgroupfs writes bypassing dbus

### DIFF
--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -3,6 +3,7 @@ package systemd
 import (
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
@@ -94,6 +95,82 @@ func TestUnitExistsIgnored(t *testing.T) {
 		if err := pm.Apply(-1); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+func TestSetUnified(t *testing.T) {
+	if !IsRunningSystemd() {
+		t.Skip("Test requires systemd.")
+	}
+	if !cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("Test requires cgroup v2.")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("Test requires root.")
+	}
+
+	testCases := []struct {
+		name     string
+		file     string
+		setVal   string
+		clearVal string
+	}{
+		{
+			name:     "memory.min",
+			file:     "memory.min",
+			setVal:   "4096",
+			clearVal: "0",
+		},
+		{
+			name:     "memory.low",
+			file:     "memory.low",
+			setVal:   "4096",
+			clearVal: "0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &cgroups.Cgroup{
+				Parent: "system.slice",
+				Name:   "system-runc_test_set_unified_" + tc.name + ".slice",
+				Resources: &cgroups.Resources{
+					Unified: map[string]string{tc.file: tc.setVal},
+				},
+			}
+			m, err := NewUnifiedManager(config, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = m.Destroy() })
+
+			if err := m.Apply(-1); err != nil {
+				t.Fatal(err)
+			}
+			if err := m.Set(config.Resources); err != nil {
+				t.Fatal(err)
+			}
+
+			val, err := cgroups.ReadFile(m.Path(""), tc.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v := strings.TrimSpace(val); v != tc.setVal {
+				t.Fatalf("after Set: expected %s=%s, got %q", tc.file, tc.setVal, v)
+			}
+
+			if err := m.SetUnified(map[string]string{tc.file: tc.clearVal}); err != nil {
+				t.Fatal(err)
+			}
+
+			val, err = cgroups.ReadFile(m.Path(""), tc.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v := strings.TrimSpace(val); v != tc.clearVal {
+				t.Fatalf("after SetUnified: expected %s=%s, got %q", tc.file, tc.clearVal, v)
+			}
+		})
 	}
 }
 

--- a/systemd/v2.go
+++ b/systemd/v2.go
@@ -516,6 +516,19 @@ func (m *UnifiedManager) Set(r *cgroups.Resources) error {
 	return m.fsMgr.Set(r)
 }
 
+// SetUnified writes unified cgroup v2 resource values directly to cgroupfs,
+// bypassing systemd's SetUnitProperties. This avoids the side effect where
+// systemd may reset unrelated cgroup properties when processing a property
+// update via dbus.
+func (m *UnifiedManager) SetUnified(unified map[string]string) error {
+	for k, v := range unified {
+		if err := cgroups.WriteFileByLine(m.path, k, v); err != nil {
+			return fmt.Errorf("unable to set unified resource %q: %w", k, err)
+		}
+	}
+	return nil
+}
+
 func (m *UnifiedManager) GetPaths() map[string]string {
 	paths := make(map[string]string, 1)
 	paths[""] = m.path


### PR DESCRIPTION
Add SetUnified method on UnifiedManager that writes unified cgroup v2 resource values directly to cgroupfs without going through systemd's SetUnitProperties dbus path.

When callers use Set() to update specific unified keys (e.g. memory.min, memory.low), the current implementation bundles those updates with all other resource properties into a single SetUnitProperties dbus call. This can cause systemd to reset unrelated cgroup properties on the unit. SetUnified avoids this by writing only the specified unified values via the existing fs2 manager path.

This is needed by kubelet to clear stale MemoryQoS cgroup protection values during feature rollback without triggering systemd side effects on CPU and memory limit properties.

 ## Context
                                                                                                                                                                             
  - KEP: [kubernetes/enhancements#2570](https://github.com/kubernetes/enhancements/issues/2570) — Memory QoS with cgroup v2                                                  
  - KEP update: [kubernetes/enhancements#5879](https://github.com/kubernetes/enhancements/pull/5879)
  - Core MemoryQoS PR: [kubernetes#137719](https://github.com/kubernetes/kubernetes/pull/137719)                                                                             
  - cpu.max regression from ungated rollback: [kubernetes#137886](https://github.com/kubernetes/kubernetes/issues/137886)                                                    
  - Re-gated setMemoryQoS: [kubernetes#138430](https://github.com/kubernetes/kubernetes/pull/138430)                                                                         
  - Failing rollback test (consumer of this PR): [kubernetes#138471](https://github.com/kubernetes/kubernetes/issues/138471) 
  - Regression: https://github.com/kubernetes/kubernetes/issues/138436