### PR TITLE
Fix BPF-related fd leaks

### DIFF
--- a/devices/ebpf_linux.go
+++ b/devices/ebpf_linux.go
@@ -15,10 +15,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func nilCloser() error {
-	return nil
-}
-
 func findAttachedCgroupDeviceFilters(dirFd int) ([]*ebpf.Program, error) {
 	type bpfAttrQuery struct {
 		TargetFd    uint32
@@ -154,7 +150,7 @@ func haveBpfProgReplace() bool {
 // Requires the system to be running in cgroup2 unified-mode with kernel >= 4.15 .
 //
 // https://github.com/torvalds/linux/commit/ebc614f687369f9df99828572b1d85a7c2de3d92
-func loadAttachCgroupDeviceFilter(insts asm.Instructions, license string, dirFd int) (func() error, error) {
+func loadAttachCgroupDeviceFilter(insts asm.Instructions, license string, dirFd int) error {
 	// Increase `ulimit -l` limit to avoid BPF_PROG_LOAD error (#2167).
 	// This limit is not inherited into the container.
 	memlockLimit := &unix.Rlimit{
@@ -166,7 +162,7 @@ func loadAttachCgroupDeviceFilter(insts asm.Instructions, license string, dirFd 
 	// Get the list of existing programs.
 	oldProgs, err := findAttachedCgroupDeviceFilters(dirFd)
 	if err != nil {
-		return nilCloser, err
+		return err
 	}
 	defer func() {
 		for _, p := range oldProgs {
@@ -184,7 +180,7 @@ func loadAttachCgroupDeviceFilter(insts asm.Instructions, license string, dirFd 
 	}
 	prog, err := ebpf.NewProgram(spec)
 	if err != nil {
-		return nilCloser, err
+		return err
 	}
 
 	// If there is only one old program, we can just replace it directly.
@@ -201,20 +197,7 @@ func loadAttachCgroupDeviceFilter(insts asm.Instructions, license string, dirFd 
 	}
 	err = link.RawAttachProgram(attachProgramOptions)
 	if err != nil {
-		return nilCloser, fmt.Errorf("failed to call BPF_PROG_ATTACH (BPF_CGROUP_DEVICE, BPF_F_ALLOW_MULTI): %w", err)
-	}
-	closer := func() error {
-		err = link.RawDetachProgram(link.RawDetachProgramOptions{
-			Target:  dirFd,
-			Program: prog,
-			Attach:  ebpf.AttachCGroupDevice,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to call BPF_PROG_DETACH (BPF_CGROUP_DEVICE): %w", err)
-		}
-		// TODO: Should we attach the old filters back in this case? Otherwise
-		//       we fail-open on a security feature, which is a bit scary.
-		return nil
+		return fmt.Errorf("failed to call BPF_PROG_ATTACH (BPF_CGROUP_DEVICE, BPF_F_ALLOW_MULTI): %w", err)
 	}
 	if !useReplaceProg {
 		logLevel := logrus.DebugLevel
@@ -254,9 +237,9 @@ func loadAttachCgroupDeviceFilter(insts asm.Instructions, license string, dirFd 
 				Attach:  ebpf.AttachCGroupDevice,
 			})
 			if err != nil {
-				return closer, fmt.Errorf("failed to call BPF_PROG_DETACH (BPF_CGROUP_DEVICE) on old filter program: %w", err)
+				return fmt.Errorf("failed to call BPF_PROG_DETACH (BPF_CGROUP_DEVICE) on old filter program: %w", err)
 			}
 		}
 	}
-	return closer, nil
+	return nil
 }

--- a/devices/ebpf_linux.go
+++ b/devices/ebpf_linux.go
@@ -182,6 +182,7 @@ func loadAttachCgroupDeviceFilter(insts asm.Instructions, license string, dirFd 
 	if err != nil {
 		return err
 	}
+	defer prog.Close()
 
 	// If there is only one old program, we can just replace it directly.
 

--- a/devices/ebpf_linux.go
+++ b/devices/ebpf_linux.go
@@ -168,6 +168,12 @@ func loadAttachCgroupDeviceFilter(insts asm.Instructions, license string, dirFd 
 	if err != nil {
 		return nilCloser, err
 	}
+	defer func() {
+		for _, p := range oldProgs {
+			p.Close()
+		}
+	}()
+
 	useReplaceProg := haveBpfProgReplace() && len(oldProgs) == 1
 
 	// Generate new program.

--- a/devices/ebpf_linux.go
+++ b/devices/ebpf_linux.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func findAttachedCgroupDeviceFilters(dirFd int) ([]*ebpf.Program, error) {
+func findAttachedCgroupDeviceFilters(dirFd int) (_ []*ebpf.Program, retErr error) {
 	type bpfAttrQuery struct {
 		TargetFd    uint32
 		AttachType  uint32
@@ -54,8 +54,17 @@ func findAttachedCgroupDeviceFilters(dirFd int) ([]*ebpf.Program, error) {
 		}
 
 		// Convert the ids to program handles.
+		// On error we don't return the programs slice, so close the fds stored there.
 		progIds = progIds[:size]
 		programs := make([]*ebpf.Program, 0, len(progIds))
+		defer func() {
+			if retErr != nil {
+				for _, p := range programs {
+					p.Close()
+				}
+			}
+		}()
+
 		for _, progId := range progIds {
 			program, err := ebpf.NewProgramFromID(ebpf.ProgramID(progId))
 			if err != nil {

--- a/devices/v2.go
+++ b/devices/v2.go
@@ -64,7 +64,7 @@ func setV2(dirPath string, r *cgroups.Resources) error {
 		return fmt.Errorf("cannot get dir FD for %s", dirPath)
 	}
 	defer unix.Close(dirFD)
-	if _, err := loadAttachCgroupDeviceFilter(insts, license, dirFD); err != nil {
+	if err := loadAttachCgroupDeviceFilter(insts, license, dirFD); err != nil {
 		if !canSkipEBPFError(r) {
 			return err
 		}


### PR DESCRIPTION
Runc test [exclude some fds](https://github.com/opencontainers/runc/blob/da3d022b06dd96a898f6d0cc1df2773df91ea035/libcontainer/integration/exec_test.go#L1751-L1753) when testing fd leaks. The leaks are coming from the cgroup device BPF programs.

With this PR, [runc tests pass fine](https://github.com/opencontainers/runc/pull/5322) and we can remove the exclude without detecting any leaks. When this is merged and released, I can update the runc PR to remove the exclude and use the new version :)

The commits explain in a little more details, but the fixes are quite simple. Please review commit by commit, as it can be tricky otherwise to understand the diff.