### PR TITLE
fs2: reset cgroup.freeze to thawed when freezing fails

### DIFF
--- a/fs2/freezer.go
+++ b/fs2/freezer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/opencontainers/cgroups"
 )
 
-func setFreezer(dirPath string, state cgroups.FreezerState) error {
+func setFreezer(dirPath string, state cgroups.FreezerState) (retErr error) {
 	var stateStr string
 	switch state {
 	case cgroups.Undefined:
@@ -37,6 +37,17 @@ func setFreezer(dirPath string, state cgroups.FreezerState) error {
 		return fmt.Errorf("freezer not supported: %w", err)
 	}
 	defer fd.Close()
+
+	// If freezing fails (for example the freeze times out), reset the cgroup
+	// back to thawed so it is not left in a half-frozen state. This mirrors
+	// the cgroup v1 behaviour (see runc#2774).
+	if state == cgroups.Frozen {
+		defer func() {
+			if retErr != nil {
+				_ = cgroups.WriteFile(dirPath, "cgroup.freeze", "0")
+			}
+		}()
+	}
 
 	if _, err := fd.WriteString(stateStr); err != nil {
 		return err


### PR DESCRIPTION
Fixes opencontainers/runc#5325

When freezing a cgroup v2 fails after the freeze has been requested — for example the freeze times out (`waitFrozen`) or the confirmed state does not match — `setFreezer` returned the error but left `cgroup.freeze` set to `1`, leaving the cgroup in a half-frozen state.

This resets `cgroup.freeze` back to `0` (thawed) on the freeze error path via a deferred best-effort write (the original error is preserved). It mirrors the existing cgroup v1 behaviour added in [runc#2774](https://github.com/opencontainers/runc/pull/2774), where `fs/freezer.go` thaws on failure.
