### PR TITLE
getallpids: Ignore removed cgroups

### DIFF
--- a/getallpids.go
+++ b/getallpids.go
@@ -1,8 +1,12 @@
 package cgroups
 
 import (
+	"errors"
 	"io/fs"
+	"os"
 	"path/filepath"
+
+	"golang.org/x/sys/unix"
 )
 
 // GetAllPids returns all pids from the cgroup identified by path, and all its
@@ -11,6 +15,11 @@ func GetAllPids(path string) ([]int, error) {
 	var pids []int
 	err := filepath.WalkDir(path, func(p string, d fs.DirEntry, iErr error) error {
 		if iErr != nil {
+			// A descendant cgroup can be removed while we walk, ignore
+			// any such error unless it's on the root (path) cgroup here
+			if p != path && ignoreCgroupRemoved(iErr) {
+				return nil
+			}
 			return iErr
 		}
 		if !d.IsDir() {
@@ -18,10 +27,18 @@ func GetAllPids(path string) ([]int, error) {
 		}
 		cPids, err := readProcsFile(p)
 		if err != nil {
+			if p != path && ignoreCgroupRemoved(err) {
+				return nil
+			}
 			return err
 		}
 		pids = append(pids, cPids...)
 		return nil
 	})
 	return pids, err
+}
+
+// ignoreCgroupRemoved reports whether err indicates the cgroup was removed.
+func ignoreCgroupRemoved(err error) bool {
+	return os.IsNotExist(err) || errors.Is(err, unix.ENODEV)
 }

--- a/getallpids_test.go
+++ b/getallpids_test.go
@@ -1,6 +1,9 @@
 package cgroups
 
 import (
+	"os"
+	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -14,4 +17,35 @@ func BenchmarkGetAllPids(b *testing.B) {
 		total += len(i)
 	}
 	b.Logf("iter: %d, total: %d", b.N, total)
+}
+
+func TestGetAllPidsIgnoresVanishedSubcgroup(t *testing.T) {
+	TestMode = true
+	defer func() { TestMode = false }()
+
+	root := t.TempDir()
+	if err := WriteFile(root, "cgroup.procs", "1\n"); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(root, "child")
+	if err := os.Mkdir(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(child, "cgroup.procs", "2\n3\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pretend "vanishing" cgroup, directory exists but not the file to read
+	if err := os.Mkdir(filepath.Join(root, "gone"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	pids, err := GetAllPids(root)
+	if err != nil {
+		t.Fatalf("GetAllPids errored on a vanished child cgroup: %v", err)
+	}
+	slices.Sort(pids)
+	if want := []int{1, 2, 3}; !slices.Equal(pids, want) {
+		t.Errorf("GetAllPids() = %v, want %v", pids, want)
+	}
 }


### PR DESCRIPTION
Determining what pids belong to a cgroup hierarchy is a racy task. At any moment you could have something like:

    1. Start recursively reading cgroup hiearchy
    2. Delete a leaf of the hierarchy
    3. Prior recursive read fails on the now deleted leaf

The pid could vanish after you determine the hierachy, it could get moved, etc. New cgroups could also be added. Its hard to get right with the current cgroupv2 api.

Let's just loosen up a bit here, if we try to read info about a cgroup and the things gone just continue onwards. We know that the state has changed since we started reading, but that's already a possible situation (i.e. you've _added_ a new cgroup, that wouldn't cause an error but you'd miss the pid in it).

Link: https://github.com/containerd/containerd/issues/13784
Signed-off-by: Andrew Halaney <ahalaney@netflix.com>