### PR TITLE
devices: work around kernel OOB write in BPF_PROG_QUERY

### DIFF
--- a/devices/ebpf_linux.go
+++ b/devices/ebpf_linux.go
@@ -23,6 +23,15 @@ func findAttachedCgroupDeviceFilters(dirFd int) (_ []*ebpf.Program, retErr error
 		AttachFlags uint32
 		ProgIds     uint64 // __aligned_u64
 		ProgCnt     uint32
+		// Kernels v6.17+ have a bug: they write the Revision field no matter
+		// what size is provided to bpf(2). This was fixed in kernel v7.2
+		// (commit 21c4b99b27f3). None of the fields below are used here,
+		// but they must be declared to work around the kernel bug.
+		_               uint32 // padding
+		ProgAttachFlags uint64 // __aligned_u64
+		LinkIDs         uint64 // __aligned_u64
+		LinkAttachFlags uint64 // __aligned_u64
+		Revision        uint64
 	}
 
 	// Currently you can only have 64 eBPF programs attached to a cgroup.


### PR DESCRIPTION
bpfAttrQuery only described the query member of union bpf_attr up to prog_cnt, and that size (32 bytes) is what is passed to bpf(2). Since Linux 6.17 ([kernel commit 120933984460, "bpf: Implement mprog API on top of existing cgroup progs")](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=120933984460), `__cgroup_bpf_query` copies `query.revision` back to userspace unconditionally, without looking at the size we passed. As revision sits at offset 56, the kernel writes 8 bytes past the end of the struct on every `BPF_PROG_QUERY`.

Depending on how the compiler lays out the frame, those 8 bytes either land on unused stack space, and nothing happens, or on live data. In runc this showed up as corrupted defer records, crashing "runc restore" in runtime.copystack, and as garbled strings. This can be seen in e.g. https://github.com/opencontainers/runc/actions/runs/30715630948. A small repro w/o runc is here: [bpfcanary.go](https://gist.github.com/kolyshkin/19c8ac541800330ed3bd41dbb992aed5). 

The kernel bug was fixed by [commit 21c4b99b27f3 ("bpf: fix BPF_PROG_QUERY OOB write and cgroup backward compat"](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=21c4b99b27f3), landed in v7.2).

Passing the larger size is safe on older kernels, as bpf(2) only
requires that the bytes beyond what it knows about are zero.