### PR TITLE
ci: bump Go, golangci-lint, codespell, and runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version:
+          - "" # Use go-version-file (see https://github.com/actions/setup-go/issues/450#issuecomment-3620402646).
+          - oldstable
+          - stable
         race: ["-race", ""]
     runs-on: ubuntu-26.04
 
@@ -29,6 +32,7 @@ jobs:
     - uses: actions/setup-go@v7
       with:
         go-version: ${{ matrix.go-version }}
+        go-version-file: go.mod # Take version from go.mod when go-version is empty.
     - run: go test -timeout 3m ${{ matrix.race }} -v ./...
 
   cgroup-v1:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,14 @@ permissions:
 
 jobs:
   cgroup-v2:
-    name: "cgroup v2 (Ubuntu 24.04)"
+    name: "cgroup v2 (Ubuntu 26.04)"
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         go-version: [1.24.x, 1.25.x]
         race: ["-race", ""]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
     - uses: actions/checkout@v7
@@ -34,7 +34,7 @@ jobs:
   cgroup-v1:
     name: "cgroup v1 (AlmaLinux 8)"
     timeout-minutes: 20
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - uses: actions/checkout@v7
 
@@ -63,6 +63,6 @@ jobs:
     needs:
       - cgroup-v2
       - cgroup-v1
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - run: echo "All jobs completed"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
       pull-requests: read
       checks: write # to allow the action to annotate code in the PR.
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:
@@ -32,7 +32,7 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.4
+          version: v2.12
       # Extra linters, only checking new code from a pull request.
       - name: lint-extra
         if: github.event_name == 'pull_request'
@@ -40,7 +40,7 @@ jobs:
           golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1
 
   go-fix:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:
@@ -54,23 +54,23 @@ jobs:
           git diff --exit-code
 
   codespell:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - uses: actions/checkout@v7
     - name: install deps
       # Use a known version of codespell.
-      run: pip install --break-system-packages codespell==v2.4.1
+      run: pip install --break-system-packages codespell==v2.4.3
     - name: run codespell
       run: codespell
 
   space-at-eol:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
       - run: if git -P grep -I -n '\s$'; then echo "^^^ extra whitespace at EOL, please fix"; exit 1; fi
 
   deps:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - uses: actions/checkout@v7
     - uses: actions/setup-go@v7
@@ -79,7 +79,7 @@ jobs:
     - run: go mod tidy --diff
 
   govulncheck:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - uses: golang/govulncheck-action@v1
 
@@ -91,6 +91,6 @@ jobs:
       - govulncheck
       - lint
       - space-at-eol
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - run: echo "All jobs completed"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,20 +37,6 @@ jobs:
         run: |
           golangci-lint run --config .golangci-extra.yml --new-from-rev=HEAD~1
 
-  go-fix:
-    runs-on: ubuntu-26.04
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 2
-      - uses: actions/setup-go@v7
-        with:
-          go-version: stable
-      - name: run go fix
-        run: |
-          go fix ./...
-          git diff --exit-code
-
   codespell:
     runs-on: ubuntu-26.04
     steps:
@@ -85,7 +71,6 @@ jobs:
     needs:
       - codespell
       - deps
-      - go-fix
       - govulncheck
       - lint
       - space-at-eol

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,8 +10,6 @@ on:
   schedule:
     # Runs at 00:00 UTC every Monday
     - cron: '0 0 * * 1'
-env:
-  GO_VERSION: 1.25
 permissions:
   contents: read
 
@@ -29,7 +27,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-go@v7
         with:
-          go-version: "${{ env.GO_VERSION }}"
+          go-version: stable
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12
@@ -47,7 +45,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-go@v7
         with:
-          go-version: "${{ env.GO_VERSION }}"
+          go-version: stable
       - name: run go fix
         run: |
           go fix ./...
@@ -75,7 +73,7 @@ jobs:
     - uses: actions/checkout@v7
     - uses: actions/setup-go@v7
       with:
-        go-version: "${{ env.GO_VERSION }}"
+        go-version: stable
     - run: go mod tidy --diff
 
   govulncheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,8 @@ formatters:
 linters:
   enable:
     - errorlint
+    - govet
+    - modernize
     - nolintlint
     - unconvert
     - unparam


### PR DESCRIPTION
 * Test matrix: `stable`, `oldstable` and a version from `go.mod`.
 * Validate jobs: simplify to just use `stable`.
 * golangci-lint: v2.4 -> v2.12.
 * codespell: 2.4.1 -> 2.4.3.
 * Runners: ubuntu-24.04 -> ubuntu-26.04.

The actions themselves are already kept current by dependabot.