### PR TITLE
ci: skip running TestParallelConnections locally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
         go-version-file: go.mod # Take version from go.mod when go-version is empty.
-    - run: go test -timeout 3m ${{ matrix.race }} -v ./...
+    - run: CGROUPS_ALLOW_UNSAFE_TESTS=true go test -timeout 3m ${{ matrix.race }} -v ./...
 
   cgroup-v1:
     name: "cgroup v1 (AlmaLinux 8)"
@@ -61,7 +61,7 @@ jobs:
         lima sudo dnf install -y golang
 
     - name: "Run unit tests"
-      run: LIMA_WORKDIR=/tmp/cgroups lima sudo GOTOOLCHAIN=auto go test -v ./...
+      run: LIMA_WORKDIR=/tmp/cgroups lima sudo GOTOOLCHAIN=auto CGROUPS_ALLOW_UNSAFE_TESTS=true go test -v ./...
 
   all-done:
     needs:

--- a/systemd/dbus_test.go
+++ b/systemd/dbus_test.go
@@ -11,6 +11,10 @@ func TestParallelConnection(t *testing.T) {
 	if !IsRunningSystemd() {
 		t.Skip("Test requires systemd.")
 	}
+	if _, ok := os.LookupEnv("CGROUPS_ALLOW_UNSAFE_TESTS"); !ok {
+		t.Skip("skipping unsafe test (can kill your desktop session); " +
+			"set CGROUPS_ALLOW_UNSAFE_TESTS=true to enable")
+	}
 	var dms []*dbusConnManager
 	for range 600 {
 		dms = append(dms, newDbusConnManager(os.Geteuid() != 0))


### PR DESCRIPTION
I nuked my GNOME session twice today by running `go test ./...` on this repo.

Apparently what happens is too many user's connections created by
`TestParallelConnection` result in this:

```
  dbus-broker-launch: ERROR sockopt_get_peerpidfd: Too many open files
                            peer_new_with_fd @ ../src/bus/peer.c +290
                            listener_dispatch @ ../src/bus/listener.c +54
  dbus-broker-launch: Caught SIGCHLD of broker.
```

Apparently dbus-broker sees EMFILE and dies, taking
the whole desktop session down with it. 💣 

Let's not run this test unless `CGROUPS_ALLOW_UNSAFE_TESTS`
is set (and set this in GHA CI).